### PR TITLE
[Refactor] Disable all goroutines

### DIFF
--- a/cmd/dumpanime/root.go
+++ b/cmd/dumpanime/root.go
@@ -9,7 +9,6 @@ import (
 	"image/gif"
 	"os"
 	"path/filepath"
-	"sync"
 	"xgtool/pkg"
 
 	"github.com/rs/zerolog/log"
@@ -47,7 +46,6 @@ func (f *flags) Flags() (fs *flag.FlagSet) {
 
 var (
 	bar *progressbar.ProgressBar
-	wg  sync.WaitGroup
 	f   flags
 )
 
@@ -101,8 +99,6 @@ func DumpAnime(ctx context.Context, args []string) (err error) {
 		_ = bar.Add(1)
 	}
 
-	wg.Wait()
-
 	return
 }
 
@@ -136,32 +132,27 @@ func dumpAnime(ai pkg.AnimeInfo, af *os.File, idx pkg.GraphicInfoIndex, gf *os.F
 	}
 
 	for i, a := range animes {
-		go func(a *pkg.Anime, i int) {
-			wg.Add(1)
-			defer wg.Done()
+		var img *gif.GIF
+		if img, err = a.GIF(p); err != nil {
+			log.Err(err).Msgf("anime: %+v", a.Info)
+			return
+		}
 
-			var img *gif.GIF
-			if img, err = a.GIF(p); err != nil {
-				log.Err(err).Msgf("anime: %+v", a.Info)
-				return
-			}
+		var out *os.File
+		if f.dr {
+			out, err = os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
+		} else {
+			out, err = os.OpenFile(fmt.Sprintf("%s/%d-%d.gif", filepath.Clean(f.outdir), ai.ID, i), os.O_WRONLY|os.O_CREATE, 0644)
+		}
+		if err != nil {
+			log.Err(err).Msgf("anime: %+v", a.Info)
+			return
+		}
 
-			var out *os.File
-			if f.dr {
-				out, err = os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
-			} else {
-				out, err = os.OpenFile(fmt.Sprintf("%s/%d-%d.gif", filepath.Clean(f.outdir), ai.ID, i), os.O_WRONLY|os.O_CREATE, 0644)
-			}
-			if err != nil {
-				log.Err(err).Msgf("anime: %+v", a.Info)
-				return
-			}
-
-			if err = gif.EncodeAll(out, img); err != nil {
-				log.Err(err).Msgf("anime: %+v", a.Info)
-				return
-			}
-		}(a, i)
+		if err = gif.EncodeAll(out, img); err != nil {
+			log.Err(err).Msgf("anime: %+v", a.Info)
+			return
+		}
 	}
 
 	return


### PR DESCRIPTION
因為 #7，先暫時將 DumpGraphic 與 DumpAnime 使用 goroutine 的部份拔掉。

## 影響

> 註：以下測試以我本人的電腦為主（2023 14" Macbook, M2 pro, 32G RAM）

DumpGraphic 的匯出效率比較：
- 使用 Goroutine：30810 it/s
- 不用 Goroutine：5391 it/s
相差約 5.7 倍

DumpAnime 的匯出效率比較：
- 使用 Goroutine：39 it/s
- 不用 Goroutine：15 it/s
相差約 2.6 倍

因為目前 Windows 平台為不可用，先暫時以這種形式緩解，未來會再做改動
